### PR TITLE
モジュール名を「github.com/appbrew/redis-inventory」に変更

### DIFF
--- a/cmd/app/display.go
+++ b/cmd/app/display.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/appbrew/redis-inventory/src/logger"
+	"github.com/appbrew/redis-inventory/src/renderer"
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/spf13/cobra"
-	"github.com/spinute/redis-inventory/src/logger"
-	"github.com/spinute/redis-inventory/src/renderer"
-	"github.com/spinute/redis-inventory/src/trie"
 )
 
 var displayCmd = &cobra.Command{

--- a/cmd/app/index.go
+++ b/cmd/app/index.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"os"
 
+	"github.com/appbrew/redis-inventory/src/adapter"
+	"github.com/appbrew/redis-inventory/src/logger"
+	"github.com/appbrew/redis-inventory/src/renderer"
+	"github.com/appbrew/redis-inventory/src/scanner"
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/mediocregopher/radix/v4"
 	"github.com/spf13/cobra"
-	"github.com/spinute/redis-inventory/src/adapter"
-	"github.com/spinute/redis-inventory/src/logger"
-	"github.com/spinute/redis-inventory/src/renderer"
-	"github.com/spinute/redis-inventory/src/scanner"
-	"github.com/spinute/redis-inventory/src/trie"
 )
 
 var indexCmd = &cobra.Command{

--- a/cmd/app/inventory.go
+++ b/cmd/app/inventory.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"os"
 
+	"github.com/appbrew/redis-inventory/src/adapter"
+	"github.com/appbrew/redis-inventory/src/logger"
+	"github.com/appbrew/redis-inventory/src/renderer"
+	"github.com/appbrew/redis-inventory/src/scanner"
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/mediocregopher/radix/v4"
 	"github.com/spf13/cobra"
-	"github.com/spinute/redis-inventory/src/adapter"
-	"github.com/spinute/redis-inventory/src/logger"
-	"github.com/spinute/redis-inventory/src/renderer"
-	"github.com/spinute/redis-inventory/src/scanner"
-	"github.com/spinute/redis-inventory/src/trie"
 )
 
 var scanCmd = &cobra.Command{

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
+	"github.com/appbrew/redis-inventory/cmd/app"
 	"github.com/spf13/cobra/doc"
-	"github.com/spinute/redis-inventory/cmd/app"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/spinute/redis-inventory
+module github.com/appbrew/redis-inventory
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/spinute/redis-inventory/cmd/app"
+	"github.com/appbrew/redis-inventory/cmd/app"
 )
 
 func main() {

--- a/src/renderer/chart.go
+++ b/src/renderer/chart.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	"code.cloudfoundry.org/bytefmt"
+	"github.com/appbrew/redis-inventory/src/server"
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/hetiansu5/urlquery"
-	"github.com/spinute/redis-inventory/src/server"
-	"github.com/spinute/redis-inventory/src/trie"
 )
 
 // NewChartRendererParams creates ChartRendererParams

--- a/src/renderer/chart_test.go
+++ b/src/renderer/chart_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spinute/redis-inventory/src/trie"
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )

--- a/src/renderer/json.go
+++ b/src/renderer/json.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/hetiansu5/urlquery"
-	"github.com/spinute/redis-inventory/src/trie"
 )
 
 // NewJSONRendererParams creates JSONRendererParams

--- a/src/renderer/json_test.go
+++ b/src/renderer/json_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/spinute/redis-inventory/src/trie"
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/src/renderer/renderer.go
+++ b/src/renderer/renderer.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"os"
 
+	"github.com/appbrew/redis-inventory/src/server"
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/rs/zerolog"
-	"github.com/spinute/redis-inventory/src/server"
-	"github.com/spinute/redis-inventory/src/trie"
 )
 
 // Renderer abstraction for rendering trie to a given output

--- a/src/renderer/table.go
+++ b/src/renderer/table.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 
 	"code.cloudfoundry.org/bytefmt"
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/hetiansu5/urlquery"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
-	"github.com/spinute/redis-inventory/src/trie"
 	"golang.org/x/text/message"
 )
 

--- a/src/renderer/table_test.go
+++ b/src/renderer/table_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/spinute/redis-inventory/src/trie"
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/src/scanner/scanner.go
+++ b/src/scanner/scanner.go
@@ -5,9 +5,9 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/appbrew/redis-inventory/src/adapter"
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/rs/zerolog"
-	"github.com/spinute/redis-inventory/src/adapter"
-	"github.com/spinute/redis-inventory/src/trie"
 )
 
 // RedisServiceInterface abstraction to access redis

--- a/src/scanner/scanner_test.go
+++ b/src/scanner/scanner_test.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/spinute/redis-inventory/src/adapter"
+	"github.com/appbrew/redis-inventory/src/adapter"
 
+	"github.com/appbrew/redis-inventory/src/trie"
 	"github.com/rs/zerolog"
-	"github.com/spinute/redis-inventory/src/trie"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )


### PR DESCRIPTION
go install が通らないため修正
多分大丈夫だと思うのですぐマージしちゃいます